### PR TITLE
JMK_69: PATCH Endpoint to update freelancer's profile status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
 			<artifactId>jm-common</artifactId>
 			<version>1.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jm_admin_management/config/SwaggerConfig.java
+++ b/src/main/java/com/jm_admin_management/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.jm_admin_management.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import java.util.List;
@@ -9,14 +10,25 @@ import java.util.List;
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${swagger.server.url1}")
+    private String serverUrl1;
+    @Value("${swagger.server.desc1}")
+    private String serverDesc1;
+    @Value("${swagger.server.url2}")
+    private String serverUrl2;
+    @Value("${swagger.server.desc2}")
+    private String serverDesc2;
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new io.swagger.v3.oas.models.info.Info()
-                        .title("Job Matrix Profile Management API")
+                        .title("Job Matrix Admin Management API")
                         .version("1.0")
-                        .description("API documentation for the Profile Management Microservice"))
-                .servers(List.of(new Server().url("http://localhost:8080").description("Local Server"),
-                        new Server().url("https://localhost:8082").description("Live")));
+                        .description("API documentation for the Admin Management Microservice"))
+                .servers(List.of(
+                        new Server().url(serverUrl1).description(serverDesc1),
+                        new Server().url(serverUrl2).description(serverDesc2)
+                ));
     }
 }

--- a/src/main/java/com/jm_admin_management/config/SwaggerConfig.java
+++ b/src/main/java/com/jm_admin_management/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.jm_admin_management.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new io.swagger.v3.oas.models.info.Info()
+                        .title("Job Matrix Profile Management API")
+                        .version("1.0")
+                        .description("API documentation for the Profile Management Microservice"))
+                .servers(List.of(new Server().url("http://localhost:8080").description("Local Server"),
+                        new Server().url("https://localhost:8082").description("Live")));
+    }
+}

--- a/src/main/java/com/jm_admin_management/controller/ProfileReviewController.java
+++ b/src/main/java/com/jm_admin_management/controller/ProfileReviewController.java
@@ -24,8 +24,8 @@ public class ProfileReviewController {
         return ResponseEntity.ok(pendingFreelancers);
     }
 
-    @PatchMapping("/freelancers/{freelancerId}/status")
-    public ResponseEntity<String> updateFreelancerStatus(
+    @PatchMapping("/freelancers/{freelancerId}/update_profile_status")
+    public ResponseEntity<String> updateProfileStatus(
             @PathVariable UUID freelancerId, @RequestBody @Valid UpdateProfileStatusRequest request){
         freelancerProfileService.updateProfileStatus(freelancerId, request.getProfileStatus());
         return ResponseEntity.ok("Freelancer profile status updated successfully.");

--- a/src/main/java/com/jm_admin_management/controller/ProfileReviewController.java
+++ b/src/main/java/com/jm_admin_management/controller/ProfileReviewController.java
@@ -1,14 +1,15 @@
 package com.jm_admin_management.controller;
 
 import com.common.entity.Freelancer;
+import com.jm_admin_management.dto.UpdateProfileStatusRequest;
 import com.jm_admin_management.service.FreelancerProfileService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/admin_management")
@@ -23,5 +24,10 @@ public class ProfileReviewController {
         return ResponseEntity.ok(pendingFreelancers);
     }
 
-
+    @PatchMapping("/freelancers/{freelancerId}/status")
+    public ResponseEntity<String> updateFreelancerStatus(
+            @PathVariable UUID freelancerId, @RequestBody @Valid UpdateProfileStatusRequest request){
+        freelancerProfileService.updateProfileStatus(freelancerId, request.getProfileStatus());
+        return ResponseEntity.ok("Freelancer profile status updated successfully.");
+    }
 }

--- a/src/main/java/com/jm_admin_management/dto/UpdateProfileStatusRequest.java
+++ b/src/main/java/com/jm_admin_management/dto/UpdateProfileStatusRequest.java
@@ -1,0 +1,12 @@
+package com.jm_admin_management.dto;
+
+import com.common.enums.ProfileStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class UpdateProfileStatusRequest {
+
+    @NotNull(message = "Profile status cannot be null")
+    private ProfileStatus profileStatus;
+}

--- a/src/main/java/com/jm_admin_management/exceptionHandling/FreelancerNotFoundException.java
+++ b/src/main/java/com/jm_admin_management/exceptionHandling/FreelancerNotFoundException.java
@@ -1,0 +1,9 @@
+package com.jm_admin_management.exceptionHandling;
+
+import java.util.UUID;
+
+public class FreelancerNotFoundException extends RuntimeException {
+    public FreelancerNotFoundException(UUID freelancerId) {
+        super("Freelancer with ID " + freelancerId + " not found");
+    }
+}

--- a/src/main/java/com/jm_admin_management/exceptionHandling/GlobalExceptionHandler.java
+++ b/src/main/java/com/jm_admin_management/exceptionHandling/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.jm_admin_management.exceptionHandling;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(FreelancerNotFoundException.class)
+    public ResponseEntity<String> handleFreelancerNotFound(FreelancerNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+}

--- a/src/main/java/com/jm_admin_management/repository/FreelancerRepository.java
+++ b/src/main/java/com/jm_admin_management/repository/FreelancerRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface FreelancerRepository extends JpaRepository<Freelancer, Long> {
+public interface FreelancerRepository extends JpaRepository<Freelancer, UUID> {
     List<Freelancer> getFreelancersByProfileStatus(ProfileStatus status);
 }

--- a/src/main/java/com/jm_admin_management/service/FreelancerProfileService.java
+++ b/src/main/java/com/jm_admin_management/service/FreelancerProfileService.java
@@ -1,9 +1,12 @@
 package com.jm_admin_management.service;
 
 import com.common.entity.Freelancer;
+import com.common.enums.ProfileStatus;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface FreelancerProfileService {
     List<Freelancer> getPendingFreelancers();
+    void updateProfileStatus(UUID freelancerId, ProfileStatus newStatus);
 }

--- a/src/main/java/com/jm_admin_management/serviceImpl/FreelancerProfileServiceImpl.java
+++ b/src/main/java/com/jm_admin_management/serviceImpl/FreelancerProfileServiceImpl.java
@@ -2,6 +2,7 @@ package com.jm_admin_management.serviceImpl;
 
 import com.common.entity.Freelancer;
 import com.common.enums.ProfileStatus;
+import com.jm_admin_management.exceptionHandling.FreelancerNotFoundException;
 import com.jm_admin_management.repository.FreelancerRepository;
 import com.jm_admin_management.service.FreelancerProfileService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -25,4 +27,14 @@ public class FreelancerProfileServiceImpl implements FreelancerProfileService {
         }
         return freelancers;
     }
+
+    @Override
+    public void updateProfileStatus(UUID freelancerId, ProfileStatus newStatus) {
+        Freelancer freelancer = freelancerRepository.findById(freelancerId)
+                .orElseThrow(() -> new FreelancerNotFoundException(freelancerId));
+
+        freelancer.setProfileStatus(newStatus);
+        freelancerRepository.save(freelancer);
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,8 @@ spring.jpa.hibernate.ddl-auto = validate
 spring.jpa.show-sql = true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.hikari.maximum-pool-size = 10
+
+swagger.server.url1=http://localhost:8080
+swagger.server.desc1=Local Server
+swagger.server.url2=https://localhost:8082
+swagger.server.desc2=Live

--- a/src/test/java/com/jm_admin_management/controller/ProfileReviewControllerTest.java
+++ b/src/test/java/com/jm_admin_management/controller/ProfileReviewControllerTest.java
@@ -78,7 +78,7 @@ class ProfileReviewControllerTest {
 
     @Test
     @DisplayName("PATCH /api/admin_management/freelancers/{freelancerId}/status should update freelancer status successfully")
-    void updateFreelancerStatus_ShouldReturnOk() throws Exception {
+    void updateProfileStatus_ShouldReturnOk() throws Exception {
         // Arrange
         UUID freelancerId = UUID.randomUUID();
         ProfileStatus newStatus = ProfileStatus.APPROVED;
@@ -87,7 +87,7 @@ class ProfileReviewControllerTest {
         String requestBody = objectMapper.writeValueAsString(request);
 
         // Act & Assert
-        mockMvc.perform(patch("/api/admin_management/freelancers/{freelancerId}/status", freelancerId)
+        mockMvc.perform(patch("/api/admin_management/freelancers/{freelancerId}/update_profile_status", freelancerId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
@@ -99,7 +99,7 @@ class ProfileReviewControllerTest {
 
     @Test
     @DisplayName("PATCH /api/admin_management/freelancers/{freelancerId}/status should return bad request for invalid status")
-    void updateFreelancerStatus_WithInvalidStatus_ShouldReturnBadRequest() throws Exception {
+    void updateProfileStatus_WithInvalidStatus_ShouldReturnBadRequest() throws Exception {
         // Arrange
         UUID freelancerId = UUID.randomUUID();
         UpdateProfileStatusRequest request = new UpdateProfileStatusRequest();
@@ -107,7 +107,7 @@ class ProfileReviewControllerTest {
         String requestBody = objectMapper.writeValueAsString(request);
 
         // Act & Assert
-        mockMvc.perform(patch("/api/admin_management/freelancers/{freelancerId}/status", freelancerId)
+        mockMvc.perform(patch("/api/admin_management/freelancers/{freelancerId}/update_profile_status", freelancerId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest())

--- a/src/test/java/com/jm_admin_management/controller/ProfileReviewControllerTest.java
+++ b/src/test/java/com/jm_admin_management/controller/ProfileReviewControllerTest.java
@@ -3,6 +3,7 @@ package com.jm_admin_management.controller;
 import com.common.entity.Freelancer;
 import com.common.enums.ProfileStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jm_admin_management.dto.UpdateProfileStatusRequest;
 import com.jm_admin_management.service.FreelancerProfileService;
 import com.jm_admin_management.test_utils.factory.FreelancerTestDataFactory;
 import org.junit.jupiter.api.DisplayName;
@@ -15,8 +16,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.List;
+import java.util.UUID;
+
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -72,4 +76,43 @@ class ProfileReviewControllerTest {
         verify(freelancerProfileService, times(1)).getPendingFreelancers();
     }
 
+    @Test
+    @DisplayName("PATCH /api/admin_management/freelancers/{freelancerId}/status should update freelancer status successfully")
+    void updateFreelancerStatus_ShouldReturnOk() throws Exception {
+        // Arrange
+        UUID freelancerId = UUID.randomUUID();
+        ProfileStatus newStatus = ProfileStatus.APPROVED;
+        UpdateProfileStatusRequest request = new UpdateProfileStatusRequest();
+        request.setProfileStatus(newStatus);
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // Act & Assert
+        mockMvc.perform(patch("/api/admin_management/freelancers/{freelancerId}/status", freelancerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("Freelancer profile status updated successfully."))
+                .andDo(MockMvcResultHandlers.print());
+
+        verify(freelancerProfileService, times(1)).updateProfileStatus(freelancerId, newStatus);
+    }
+
+    @Test
+    @DisplayName("PATCH /api/admin_management/freelancers/{freelancerId}/status should return bad request for invalid status")
+    void updateFreelancerStatus_WithInvalidStatus_ShouldReturnBadRequest() throws Exception {
+        // Arrange
+        UUID freelancerId = UUID.randomUUID();
+        UpdateProfileStatusRequest request = new UpdateProfileStatusRequest();
+        request.setProfileStatus(null); // Simulate invalid status
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        // Act & Assert
+        mockMvc.perform(patch("/api/admin_management/freelancers/{freelancerId}/status", freelancerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print());
+
+        verify(freelancerProfileService, never()).updateProfileStatus(any(), any());
+    }
 }

--- a/src/test/java/com/jm_admin_management/exceptionHandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/jm_admin_management/exceptionHandling/GlobalExceptionHandlerTest.java
@@ -1,0 +1,30 @@
+package com.jm_admin_management.exceptionHandling;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("handleFreelancerNotFound should return NOT_FOUND status and the correct message")
+    void handleFreelancerNotFound_ShouldReturnNotFoundAndCorrectMessage() {
+        // Arrange
+        UUID freelancerId = UUID.randomUUID();
+        FreelancerNotFoundException exception = new FreelancerNotFoundException(freelancerId);
+
+        // Act
+        ResponseEntity<String> response = globalExceptionHandler.handleFreelancerNotFound(exception);
+
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("Freelancer with ID " + freelancerId + " not found", response.getBody());
+    }
+}

--- a/src/test/java/com/jm_admin_management/serviceImpl/FreelancerProfileServiceImplTest.java
+++ b/src/test/java/com/jm_admin_management/serviceImpl/FreelancerProfileServiceImplTest.java
@@ -2,6 +2,7 @@ package com.jm_admin_management.serviceImpl;
 
 import com.common.entity.Freelancer;
 import com.common.enums.ProfileStatus;
+import com.jm_admin_management.exceptionHandling.FreelancerNotFoundException;
 import com.jm_admin_management.repository.FreelancerRepository;
 import com.jm_admin_management.test_utils.factory.FreelancerTestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,9 +12,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
+import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -111,5 +112,42 @@ public class FreelancerProfileServiceImplTest {
         assertNotNull(result);
         assertEquals(1, result.size());
         assertEquals(ProfileStatus.PENDING, result.get(0).getProfileStatus());
+    }
+
+    @Test
+    @DisplayName("updateProfileStatus should update freelancer status when freelancer exists")
+    void updateProfileStatus_WhenFreelancerExists_ShouldUpdateStatus() {
+        // Arrange
+        UUID freelancerId = UUID.randomUUID();
+        ProfileStatus newStatus = ProfileStatus.APPROVED;
+        Freelancer existingFreelancer = new Freelancer();
+        existingFreelancer.setFreelancerId(freelancerId);
+        existingFreelancer.setProfileStatus(ProfileStatus.PENDING);
+
+        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.of(existingFreelancer));
+        when(freelancerRepository.save(existingFreelancer)).thenReturn(existingFreelancer);
+
+        // Act
+        freelancerProfileService.updateProfileStatus(freelancerId, newStatus);
+
+        // Assert
+        assertEquals(newStatus, existingFreelancer.getProfileStatus());
+        verify(freelancerRepository, times(1)).findById(freelancerId);
+        verify(freelancerRepository, times(1)).save(existingFreelancer);
+    }
+
+    @Test
+    @DisplayName("updateProfileStatus should throw FreelancerNotFoundException when freelancer does not exist")
+    void updateProfileStatus_WhenFreelancerDoesNotExist_ShouldThrowException() {
+        // Arrange
+        UUID freelancerId = UUID.randomUUID();
+        ProfileStatus newStatus = ProfileStatus.APPROVED;
+
+        when(freelancerRepository.findById(freelancerId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(FreelancerNotFoundException.class, () -> freelancerProfileService.updateProfileStatus(freelancerId, newStatus));
+        verify(freelancerRepository, times(1)).findById(freelancerId);
+        verify(freelancerRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/jm_admin_management/test_utils/factory/FreelancerTestDataFactory.java
+++ b/src/test/java/com/jm_admin_management/test_utils/factory/FreelancerTestDataFactory.java
@@ -38,7 +38,7 @@ public class FreelancerTestDataFactory {
             "Data scientist with background in machine learning and statistical analysis."
     };
 
-    private static final Double[] HOURLY_RATES = { 75.0, 85.0, 65.0, 90.0, 95.0};
+    private static final int[] HOURLY_RATES = { 75, 85, 65, 90, 95 };
 
     private static final String[] ADDRESSES = {
             "123 Tech Street",


### PR DESCRIPTION
This PR adds a new PATCH endpoint to allow admins to update the profile status of a freelancer (e.g., approve or reject profiles) within the jm_admin_management microservice.

**Endpoint Details:**
 PATCH /api/admin_management/freelancers/{freelancerId}/status

**Request Body:**
{
  "profileStatus": "APPROVED" // or "REJECTED"
}

**Response:**
200 OK with success message on successful update.
404 Not Found if the freelancer ID does not exist.